### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/regommend.go
+++ b/regommend.go
@@ -16,7 +16,7 @@ var (
 	mutex sync.RWMutex
 )
 
-// Returns the existing engine table with given name or creates a new one
+// Table returns the existing engine table with given name or creates a new one
 // if the table does not exist yet.
 func Table(table string) *RegommendTable {
 	mutex.RLock()

--- a/regommenditem.go
+++ b/regommenditem.go
@@ -23,7 +23,7 @@ type RegommendItem struct {
 	data map[interface{}]float64
 }
 
-// Returns a newly created RegommendItem.
+// CreateRegommendItem returns a newly created RegommendItem.
 // Parameter key is the item's key.
 // Parameter data is the item's value.
 func CreateRegommendItem(key interface{}, data map[interface{}]float64) RegommendItem {
@@ -33,13 +33,13 @@ func CreateRegommendItem(key interface{}, data map[interface{}]float64) Regommen
 	}
 }
 
-// Returns the key of this item.
+// Key returns the key of this item.
 func (item *RegommendItem) Key() interface{} {
 	// immutable
 	return item.key
 }
 
-// Returns the value of this item.
+// Data returns the value of this item.
 func (item *RegommendItem) Data() map[interface{}]float64 {
 	// immutable
 	return item.data

--- a/regommendtable.go
+++ b/regommendtable.go
@@ -36,7 +36,7 @@ type RegommendTable struct {
 	aboutToDeleteItem func(item *RegommendItem)
 }
 
-// Returns how many items are currently stored in the engine.
+// Count returns how many items are currently stored in the engine.
 func (table *RegommendTable) Count() int {
 	table.RLock()
 	defer table.RUnlock()
@@ -74,7 +74,7 @@ func (table *RegommendTable) SetLogger(logger *log.Logger) {
 	table.logger = logger
 }
 
-// Adds a key/value pair to the engine.
+// Add adds a key/value pair to the engine.
 // Parameter key is the item's engine-key.
 // Parameter data is the item's value.
 func (table *RegommendTable) Add(key interface{}, data map[interface{}]float64) *RegommendItem {
@@ -135,7 +135,7 @@ func (table *RegommendTable) Exists(key interface{}) bool {
 	return ok
 }
 
-// Get an item from the engine and mark it to be kept alive.
+// Value gets an item from the engine and mark it to be kept alive.
 func (table *RegommendTable) Value(key interface{}) (*RegommendItem, error) {
 	table.RLock()
 	r, ok := table.items[key]


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!